### PR TITLE
Support systemd and potentially other inits with a telinit wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/fakeinit

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ handholding, this script is not for you.
 
 ## Compatibility
 
-This script is designed for systems using sysvinit that support the `telinit u`
-command to reload `/sbin/init`. If your system uses something else, you will
-have to adapt it, or this might not work at all. You're on your own here.
+This script is designed for init systems that support the `telinit u` command to
+reload the init binary. This includes sysvinit and systemd. If your init system
+works a different way, you will have to adapt it, or this might not work at
+all. You're on your own here.
 
 You should always test this in a VM first. You can grab a tarball of your live
 root filesystem, extract it into a VM image, get your VM up and running (boot

--- a/takeover.sh
+++ b/takeover.sh
@@ -2,6 +2,7 @@
 set -e
 
 TO=/takeover
+OLD_INIT=$(readlink /proc/1/exe)
 PORT=80
 
 cd "$TO"
@@ -46,7 +47,7 @@ if [ "$a" != "OK" ] ; then
 fi
 
 ./busybox echo "Preparing init..."
-./busybox cat >tmp/init <<EOF
+./busybox cat >tmp/${OLD_INIT##*/} <<EOF
 #!${TO}/busybox sh
 
 exec <"${TO}/${TTY}" >"${TO}/${TTY}" 2>"${TO}/${TTY}"
@@ -54,11 +55,12 @@ cd "${TO}"
 
 ./busybox echo "Init takeover successful"
 ./busybox echo "Pivoting root..."
+./busybox mount --make-rprivate /
 ./busybox pivot_root . old_root
 ./busybox echo "Chrooting and running init..."
 exec ./busybox chroot . /fakeinit
 EOF
-./busybox chmod +x tmp/init
+./busybox chmod +x tmp/${OLD_INIT##*/}
 
 ./busybox echo "Starting secondary sshd"
 
@@ -78,7 +80,7 @@ fi
 ./busybox echo "You may then kill the remnants of this session and any remaining"
 ./busybox echo "processes from your new SSH session, and umount the old root filesystem."
 
-./busybox mount --bind tmp/init /sbin/init
+./busybox mount --bind tmp/${OLD_INIT##*/} ${OLD_INIT}
 
 telinit u
 

--- a/takeover.sh
+++ b/takeover.sh
@@ -2,7 +2,6 @@
 set -e
 
 TO=/takeover
-OLD_TELINIT=/sbin/telinit
 PORT=80
 
 cd "$TO"
@@ -47,7 +46,6 @@ if [ "$a" != "OK" ] ; then
 fi
 
 ./busybox echo "Preparing init..."
-./busybox cp $OLD_TELINIT tmp/telinit
 ./busybox cat >tmp/init <<EOF
 #!${TO}/busybox sh
 
@@ -80,9 +78,9 @@ fi
 ./busybox echo "You may then kill the remnants of this session and any remaining"
 ./busybox echo "processes from your new SSH session, and umount the old root filesystem."
 
-./busybox mount --bind tmp /sbin
+./busybox mount --bind tmp/init /sbin/init
 
-./tmp/telinit u
+telinit u
 
 ./busybox sleep 10
 


### PR DESCRIPTION
Tested with openSUSE 42.1 to SystemRescueCd. Fixes #3.