### PR TITLE
Bind mount /dev/pts instead of mounting new one

### DIFF
--- a/takeover.sh
+++ b/takeover.sh
@@ -31,7 +31,7 @@ if ! ./busybox mount -t devtmpfs dev dev; then
     ./busybox rm -rf dev/pts
     ./busybox mkdir dev/pts
 fi
-./busybox mount -t devpts devpts dev/pts
+./busybox mount --bind /dev/pts dev/pts
 
 TTY="$(./busybox tty)"
 


### PR DESCRIPTION
Since https://github.com/torvalds/linux/commit/eedf265aa003b4781de24cfed40a655a664457e6 (Linux 4.7), a newly mounted devpts is no longer shared with the "host". This breaks the TTY handling.