### PR TITLE
Start sshd with PermitRootLogin=yes

### DIFF
--- a/takeover.sh
+++ b/takeover.sh
@@ -65,7 +65,7 @@ EOF
 ./busybox echo "Starting secondary sshd"
 
 ./busybox chroot . /usr/bin/ssh-keygen -A
-./busybox chroot . /usr/sbin/sshd -p $PORT
+./busybox chroot . /usr/sbin/sshd -p $PORT -o PermitRootLogin=yes
 
 ./busybox echo "You should SSH into the secondary sshd now."
 ./busybox echo "Type OK to continue"


### PR DESCRIPTION
Some distributions, such as Debian, disable root login in sshd by default. This presents a problem when such distributions are used as the temporary system in takeover.sh.

This commit explicitly enables root login in the sshd command line, overriding the sshd configuration file.