### PR TITLE
Prefer reexec via systemctl over telinit

### DIFF
--- a/takeover.sh
+++ b/takeover.sh
@@ -82,7 +82,11 @@ fi
 
 ./busybox mount --bind tmp/${OLD_INIT##*/} ${OLD_INIT}
 
-telinit u
+if command -v systemctl >/dev/null; then
+    systemctl daemon-reexec
+else
+    telinit u
+fi
 
 ./busybox sleep 10
 


### PR DESCRIPTION
On a recent Arch system I ran into `telinit` just not existing anymore, so prefer to call systemd directly.